### PR TITLE
Add options to include only parts of a page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "export-logseq-notes"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "export-logseq-notes"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Daniel Imfeld <daniel@imfeld.dev>"]
 edition = "2021"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,7 @@ fn main() -> Result<()> {
             }
             roam_edn::graph_from_roam_edn(&raw_data)?
         }
-        PkmProduct::Logseq => {
-            logseq::LogseqGraph::build(config.path.clone(), config.allow_daily_notes)?
-        }
+        PkmProduct::Logseq => logseq::LogseqGraph::build(config.path.clone(), config.daily_notes)?,
     };
 
     let pages = make_pages(&graph, &hbars, &highlighter, &config)?;


### PR DESCRIPTION
This enables publishing partial pages, specifically with the use case to publish journal pages but only selected parts while omitting private sections.