### PR TITLE
Scripting and tag management improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -441,7 +441,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "export-logseq-notes"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -460,6 +460,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "smartstring",
  "structopt",
  "syntect",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "export-logseq-notes"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Daniel Imfeld <daniel@imfeld.dev>"]
 edition = "2021"
 
@@ -23,6 +23,7 @@ rhai = { version = "1.10.0", features = ["sync"] }
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 smallvec = "1.6.1"
+smartstring = "1.0.1"
 structopt = "0.3.21"
 syntect = "5.0.0"
 toml = "0.5.8"
@@ -32,3 +33,6 @@ zip = "0.6.2"
 
 [dev-dependencies]
 indoc = "1.0.6"
+
+[profile.release]
+debug = 1

--- a/export-logseq-notes.toml
+++ b/export-logseq-notes.toml
@@ -25,33 +25,6 @@ highlight_class_prefix = "hljs-"
 
 ##### Control Included Pages #####
 
-# Include pages with this tag that are not otherwise excluded. This hashtag will be removed from the output
-include = "note-export"
-
-# Include pages where this attribute is present and has the value "true".
-# When include_all is set, this attribute can also be used to exclude a page if it is present with a non-"true" value.
-bool_include_attr = "public"
-
-# Set to true to include all pages, except daily notes and those excluded by the `exclude` setting.
-include_all = false
-
-# Allow daily notes to be included
-allow_daily_notes = false
-
-# Additional tags to indicate that a page should be included. These tags will not be removed
-# from the rendered output.
-also = [
-  "UI",
-  "Sermons",
-  "syntax-test"
-]
-
-# Pages that reference any of these tags will be excluded
-exclude = [
-  "Areas",
-  "CV"
-]
-
 
 ##### Tags Output ####
 
@@ -59,21 +32,11 @@ exclude = [
 # template to populate front matter for a CMS
 tags_attr = "Tags"
 
-# Use all hashtags in a page when gathering tags, not just values of the tags_attr
-use_all_hashtags = true
-
 # When gathering tags for a page template, ignore these tags
 # For example, your book note pages may have lines like this:
 # Tags:: #Books #[[In Progress]] #Finance
 # So you can add "Books" and "In Progress" here to prevent them from
 # being listed as tags for a page and cluttering up the tags.
-exclude_tags = [
-  "Books",
-  "In Progress",
-  "Done"
-]
-
-# Skip rendering blocks with these attributes. Their children, if any, will still render.
 omit_attributes = [
   "Progress",
   "Tags"

--- a/sample.rhai
+++ b/sample.rhai
@@ -1,62 +1,135 @@
+// mapping of word occurrence to the corresponding tag.
+let autotags = #{
+  "sql": "databases",
+  "rust": "rust",
+  "ml": "Machine Learning",
+  "machine learning": "Machine Learning"
+};
 
 if page.is_journal {
-  page.url_base = "journals";
-  page.path_base = "journals";
+  page.url_base = "/journals";
+  page.path_base = "pkm-pages/journals";
+
+  // The title has dashes instead of underscores, which makes for a nicer id.
+  page.path_name = page.title + ".html";
 
   let saw_content_block = false;
-  page.each_block(1, |depth| {
+
+  // Iterate over every block in the page, with a max depth of 1.
+  // Depth starts at 0, which is the "page" block.
+  each_block(1, |block, depth| {
     if depth == 0 {
-      // The top level
-      this.view_type = ViewType::Document;
-    } else if this.contents == "Journal" {
-      this.include = BlockInclude::OnlyChildren;
+      // The top level. All blocks will inherit from this view_type if they don't specify something else.
+      block.view_type = ViewType::Document;
+    } else if block.contents == "Journal" {
+      // Include the Journal block, but skip rendering it and render its children in its place.
+      block.include = BlockInclude::OnlyChildren;
       saw_content_block = true;
-      debug(this.contents);
-    } else if this.contents == "Learning" ||
-        this.contents == "Links" {
-      this.view_type = ViewType::Bullet;
-      this.heading = 3;
-      this.include = BlockInclude::IfChildrenPresent;
+
+      // Scan the journal block and its children for tags.
+      let tags = autotag(autotags, block.id);
+      page.add_tags(tags);
+    } else if block.contents == "Learning" ||
+        block.contents == "Links" {
+      // Render these as bulleted lists, if they aren't empty.
+      block.view_type = ViewType::Bullet;
+      block.heading = 3;
+      block.include = BlockInclude::IfChildrenPresent;
       saw_content_block = true;
-      debug(this.contents);
-    } else if depth > 0 {
-      this.include = BlockInclude::Exclude;
+
+      let tags = autotag(autotags, block.id);
+      page.add_tags(tags);
+    } else if depth == 1 {
+      // Exclude all other blocks from the pages.
+      block.include = BlockInclude::Exclude;
     }
   });
 
-  if saw_content_block {
-    debug(page.title);
-  }
-  page.allow_render(saw_content_block);
+  page.include = saw_content_block;
 } else {
-  page.url_base = "notes";
-  page.path_base = "pages";
+  page.url_base = "/notes";
+  page.path_base = "pkm-pages/notes";
 
   let include = false;
   let exclude = false;
 
+  // Handle Logseq "public" attribute
   if page.get_attr_first("public") == "true" {
     include = true;
   }
 
+  // Allow changing the URL through an attribute like note-export:: a_new_url
+  let new_slug = page.get_attr_first("note-export");
+  if new_slug.len > 0 {
+    page.path_name = new_slug + ".html";
+  }
+
+  // If these tags occur in any block, omit the page.
   let exclude_tags = [
     "Areas",
-    "CV"
-  ];
-
-  let include_tags = [
-    "UI",
+    "CV",
     "syntax-test"
   ];
 
-  page.each_block(9999, |depth| {
-    let tags = this.tags;
+  // Include pages that have these tags somewhere.
+  let include_tags = [
+    "learning",
+    "svelte",
+    "SQL",
+    "database",
+    "Mental Models",
+    "JTBD",
+    "note-export"
+  ];
+
+  each_block(9999, |block, depth| {
+    let tags = block.tags;
     if !exclude && tags.some(|t| t in exclude_tags) {
       exclude = true;
     } else if !include && tags.some(|t| t in include_tags) {
       include = true;
     }
+
+    // Add all the hashtags seen in this block.
+    page.add_tags(tags);
+
+    // Don't publish synced highlights
+    if block.contents.starts_with("Highlights first synced") ||
+          block.contents.starts_with("New highlights added") {
+      block.include = BlockInclude::Exclude;
+    }
   });
 
-  page.allow_render(include && !exclude);
+  if !exclude {
+    // If we're not explicitly excluding this page, allow it to be embedded by other pages,
+    // even if it didn't qualify to be included as its own page.
+    page.allow_embedding = AllowEmbed::Yes;
+  }
+
+  let allow = include && !exclude;
+  page.include = allow;
+  if allow {
+    // Remove all these tags from the page.
+    let omit_tags = [
+      "Articles",
+      "Inbox",
+      "In Progress",
+      "Newsletter Item",
+      "Done",
+      "Readwise",
+      "Deliberate Practice",
+      "Video",
+      "note-export",
+      "public",
+      "progress",
+      "Progress",
+      "tags",
+      "Tags"
+    ];
+
+    for tag in omit_tags {
+      page.remove_tag(tag);
+    }
+  }
 }
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,9 +57,6 @@ struct InputConfig {
     #[structopt(short, long, env, help = "Attribute that indicates tags for a page")]
     pub tags_attr: Option<String>,
 
-    #[structopt(long, env, help = "Tag a page with all included hashtags")]
-    pub use_all_hashtags: Option<bool>,
-
     #[structopt(
         long,
         env,
@@ -133,24 +130,12 @@ pub struct Config {
     pub script: PathBuf,
     pub product: PkmProduct,
     pub base_url: Option<String>,
-    // pub namespace_dirs: bool, // TODO
-    // pub include: Option<String>,
-    // pub bool_include_attr: Option<String>,
-    // pub also: Vec<String>,
-    // pub include_all: bool,
-    // pub daily_notes: DailyNotes,
-    // pub exclude: Vec<String>,
-    // pub exclude_tags: Vec<String>,
     pub omit_attributes: Vec<String>,
-    // pub include_blocks_with_tags: Vec<String>,
-    // pub include_blocks_with_prefix: Vec<String>,
     pub highlight_class_prefix: Option<String>,
     pub template: Option<PathBuf>,
     pub extension: String,
     pub tags_attr: Option<String>,
-    pub use_all_hashtags: bool,
     pub filter_link_only_blocks: bool,
-    // pub include_all_page_embeds: bool, // TODO
     pub class_bold: String,
     pub class_italic: String,
     pub class_strikethrough: String,
@@ -209,59 +194,23 @@ impl Config {
             }
         };
 
-        // let allow_daily_notes =
-        //     merge_default(cmdline_cfg.allow_daily_notes, file_cfg.allow_daily_notes);
-
-        // let only_daily_notes =
-        //     merge_default(cmdline_cfg.only_daily_notes, file_cfg.only_daily_notes);
-
-        // let daily_notes = match (allow_daily_notes, only_daily_notes) {
-        //     (_, true) => DailyNotes::Exclusive,
-        //     (true, false) => DailyNotes::Allow,
-        //     (false, false) => DailyNotes::Deny,
-        // };
-
         let mut cfg = Config {
             path: merge_required("data", cmdline_cfg.data, file_cfg.data)?,
             output: merge_required("output", cmdline_cfg.output, file_cfg.output)?,
             script: merge_required("script", cmdline_cfg.script, file_cfg.script)?,
             product: merge_default(cmdline_cfg.product, file_cfg.product),
             base_url: cmdline_cfg.base_url.or(file_cfg.base_url),
-            // namespace_dirs: merge_default(cmdline_cfg.namespace_dirs, file_cfg.namespace_dirs),
-            // include: cmdline_cfg.include.or(file_cfg.include),
-            // bool_include_attr: cmdline_cfg.bool_include_attr.or(file_cfg.bool_include_attr),
-            // also: merge_default(cmdline_cfg.also, file_cfg.also),
-            // include_all: merge_default(cmdline_cfg.include_all, file_cfg.include_all),
-            // daily_notes,
-            // exclude: merge_default(cmdline_cfg.exclude, file_cfg.exclude),
-            // exclude_tags: merge_default(cmdline_cfg.exclude_tags, file_cfg.exclude_tags),
             omit_attributes: merge_default(cmdline_cfg.omit_attributes, file_cfg.omit_attributes),
-            // include_blocks_with_tags: merge_default(
-            //     cmdline_cfg.include_blocks_with_tags,
-            //     file_cfg.include_blocks_with_tags,
-            // ),
-            // include_blocks_with_prefix: merge_default(
-            //     cmdline_cfg.include_blocks_with_prefix,
-            //     file_cfg.include_blocks_with_prefix,
-            // ),
             highlight_class_prefix: cmdline_cfg
                 .highlight_class_prefix
                 .or(file_cfg.highlight_class_prefix),
             template: cmdline_cfg.template.or(file_cfg.template),
             extension: merge_default(cmdline_cfg.extension, file_cfg.extension),
             tags_attr: cmdline_cfg.tags_attr.or(file_cfg.tags_attr),
-            use_all_hashtags: merge_default(
-                cmdline_cfg.use_all_hashtags,
-                file_cfg.use_all_hashtags,
-            ),
             filter_link_only_blocks: merge_default(
                 cmdline_cfg.filter_link_only_blocks,
                 file_cfg.filter_link_only_blocks,
             ),
-            // include_all_page_embeds: merge_default(
-            //     cmdline_cfg.include_all_page_embeds,
-            //     file_cfg.include_all_page_embeds,
-            // ),
             class_bold: merge_default(cmdline_cfg.class_bold, file_cfg.class_bold),
             class_italic: merge_default(cmdline_cfg.class_italic, file_cfg.class_italic),
             class_strikethrough: merge_default(
@@ -300,25 +249,6 @@ impl Config {
             class_heading3: merge_default(cmdline_cfg.class_heading3, file_cfg.class_heading3),
             class_heading4: merge_default(cmdline_cfg.class_heading4, file_cfg.class_heading4),
         };
-
-        // For environment variables, handle comma separated strings for vectors
-        // cfg.also = cfg
-        //     .also
-        //     .iter()
-        //     .flat_map(|w| w.split(',').map(|t| String::from(t.trim())))
-        //     .collect::<Vec<_>>();
-
-        // cfg.exclude = cfg
-        //     .exclude
-        //     .iter()
-        //     .flat_map(|w| w.split(',').map(|t| String::from(t.trim())))
-        //     .collect::<Vec<_>>();
-
-        // cfg.exclude_tags = cfg
-        //     .exclude_tags
-        //     .iter()
-        //     .flat_map(|w| w.split(',').map(|t| String::from(t.trim())))
-        //     .collect::<Vec<_>>();
 
         // Make sure base url starts and ends with a slash
         cfg.base_url = cfg.base_url.map(|url| {


### PR DESCRIPTION
- Move each_block out to global namespace to avoid reentrant mutex and improve error surfacing.
- Do full parse when detecting hashtags, to avoid hashtag false positives inside code blocks and such.
- Add autotag function to scan blocks for text and generate tags.
- Prevent duplicate tags in tag script functions