### PR TITLE
Output `p` tags for document view mode instead of list tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "export-logseq-notes"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "ahash 0.8.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "export-logseq-notes"
-version = "0.3.10"
+version = "0.4.0"
 authors = ["Daniel Imfeld <daniel@imfeld.dev>"]
 edition = "2021"
 


### PR DESCRIPTION
This makes for much better output when exporting a document in view mode and also converts hierarchical content in the logseq page into flattened output.